### PR TITLE
REBEL-63: Implement Apple-R for Services

### DIFF
--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -203,10 +203,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 {
   RCTAssertMainThread();
 
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(reload)
-                                               name:RCTReloadNotification
-                                             object:nil];
+  // [[NSNotificationCenter defaultCenter] addObserver:self
+  //                                          selector:@selector(reload)
+  //                                              name:RCTReloadNotification
+  //                                            object:nil];
 
 #if TARGET_IPHONE_SIMULATOR
   RCTKeyCommands *commands = [RCTKeyCommands sharedInstance];


### PR DESCRIPTION
Disabling RN from taking control when the developer presses Apple-R. Instead, RC will take control and cycle through all the servers.
