### PR TITLE
Ignore UIAlertView deprecation warning

### DIFF
--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -203,10 +203,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 {
   RCTAssertMainThread();
 
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(reload)
-                                               name:RCTReloadNotification
-                                             object:nil];
+  // [[NSNotificationCenter defaultCenter] addObserver:self
+  //                                          selector:@selector(reload)
+  //                                              name:RCTReloadNotification
+  //                                            object:nil];
 
 #if TARGET_IPHONE_SIMULATOR
   RCTKeyCommands *commands = [RCTKeyCommands sharedInstance];

--- a/React/Base/RCTUtils.h
+++ b/React/Base/RCTUtils.h
@@ -80,11 +80,14 @@ RCT_EXTERN BOOL RCTForceTouchAvailable(void);
 
 // Return a UIAlertView initialized with the given values
 // or nil if running in an app extension
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 RCT_EXTERN UIAlertView *__nullable RCTAlertView(NSString *title,
                                                 NSString *__nullable message,
                                                 id __nullable delegate,
                                                 NSString *__nullable cancelButtonTitle,
                                                 NSArray<NSString *> *__nullable otherButtonTitles);
+#pragma clang diagnostic pop
 
 // Create an NSError in the RCTErrorDomain
 RCT_EXTERN NSError *RCTErrorWithMessage(NSString *message);


### PR DESCRIPTION
- Ignore the UIAlertView deprecation warning for now.
- @sghiassy 
